### PR TITLE
fix: remove empty changelog-sections override in release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -12,7 +12,6 @@
           "search-pattern": "\\*\\*Version\\*\\*: [0-9]+\\.[0-9]+\\.[0-9]+"
         }
       ],
-      "changelog-sections": []
     }
   }
 }


### PR DESCRIPTION
Empty `changelog-sections: []` overrides release-please built-in defaults, causing it to treat no commit type as "user facing" and skip all commits. Removing this key restores defaults (feat, fix, perf trigger releases).

https://claude.ai/code/session_0118nvDucv6ZEuDHMnLCx8aS