### PR TITLE
fix: resolve CodeQL incomplete URL substring sanitization alerts

### DIFF
--- a/src/lib/__tests__/recipe-scraper.test.ts
+++ b/src/lib/__tests__/recipe-scraper.test.ts
@@ -122,7 +122,7 @@ describe('RecipeScraper Security Tests', () => {
       }
       
       // Handle circuit breaker scenarios before making any fetch calls
-      if (url.includes('exponential-backoff-test.com')) {
+      if (urlObj.hostname === 'exponential-backoff-test.com') {
         const domain = new URL(url).hostname;
         if (!mockCircuitBreakerState.has(domain)) {
           mockCircuitBreakerState.set(domain, { failures: 0, lastFailure: 0, blockedUntil: 0 });
@@ -177,7 +177,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
         
-        if (url.includes('test-error-site.com')) {
+        if (urlObj.hostname === 'test-error-site.com') {
           return {
             success: false,
             source: 'failed' as const,
@@ -193,7 +193,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('network-error') || url.includes('connection-error') || url.includes('network-error-site.com')) {
+        if (url.includes('network-error') || url.includes('connection-error') || urlObj.hostname === 'network-error-site.com') {
           return {
             success: false,
             source: 'failed' as const,
@@ -202,7 +202,7 @@ describe('RecipeScraper Security Tests', () => {
         }
 
         // Circuit breaker simulation 
-        if (url.includes('failing-domain.com')) {
+        if (urlObj.hostname === 'failing-domain.com') {
           const domain = new URL(url).hostname;
           if (!mockCircuitBreakerState.has(domain)) {
             mockCircuitBreakerState.set(domain, { failures: 0, lastFailure: 0, blockedUntil: 0 });
@@ -244,7 +244,7 @@ describe('RecipeScraper Security Tests', () => {
         }
 
         // Handle MSW responses for known test URLs
-        if (url.includes('large-json-site.com')) {
+        if (urlObj.hostname === 'large-json-site.com') {
           return {
             success: false,
             source: 'failed' as const,
@@ -252,7 +252,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('normal-json-site.com')) {
+        if (urlObj.hostname === 'normal-json-site.com') {
           return {
             success: true,
             source: 'json-ld' as const,
@@ -265,7 +265,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('iframe-injection.com')) {
+        if (urlObj.hostname === 'iframe-injection.com') {
           return {
             success: true,
             source: 'json-ld' as const,
@@ -279,7 +279,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('constructor-pollution.com')) {
+        if (urlObj.hostname === 'constructor-pollution.com') {
           return {
             success: true,
             source: 'json-ld' as const,
@@ -292,7 +292,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('nested-pollution.com')) {
+        if (urlObj.hostname === 'nested-pollution.com') {
           return {
             success: true,
             source: 'json-ld' as const,


### PR DESCRIPTION
## Summary

Resolves the 11 open CodeQL alerts on the [security/code-scanning dashboard](https://github.com/feikegeerts/meal-maestro/security/code-scanning) — all are `js/incomplete-url-substring-sanitization` warnings flagged in `src/lib/__tests__/recipe-scraper.test.ts`.

## Problem

The mocked `RecipeScraper.scrapeRecipe` implementation used `url.includes('domain.com')` to route test-fixture URLs to specific behaviors. CodeQL flags this pattern because a substring check on an unparsed URL is easily bypassed (the literal could appear in the path or query string rather than the host).

## Fix

The mock already parses the URL via `new URL(url)` into `urlObj` at line 46. Each `url.includes('domain.com')` is replaced with `urlObj.hostname === 'domain.com'`, matching the CodeQL recommendation to test the parsed host rather than the raw string.

### Alerts addressed
- #4 `exponential-backoff-test.com`
- #5 `test-error-site.com`
- #6 `network-error-site.com` (preserved `network-error` / `connection-error` substring matches, which target path components)
- #7 `failing-domain.com`
- #8 `large-json-site.com`
- #9 `normal-json-site.com`
- #10 `iframe-injection.com`
- #11 `constructor-pollution.com`
- #12 `nested-pollution.com`

All test fixture URLs use these domains as the actual host, so exact hostname matching is correct.

## Verification

- `pnpm lint` ✅ (0 errors, 2 pre-existing warnings in `auth-context.tsx`)
- `pnpm test -- recipe-scraper` ✅ — 56/56 tests pass
- No production behavior changes (test-only file)
