### PR TITLE
ci: remove redundant manual Vercel deploy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,60 +28,6 @@ jobs:
       - run: pnpm run test:ci
       - run: pnpm run test:integration
 
-  deploy-preview:
-    name: Deploy Preview
-    needs: ci
-    if: github.event_name == 'pull_request'
-    runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm add -g vercel@latest
-      - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - id: deploy
-        run: echo "url=$(vercel deploy --prebuilt --archive=tgz --token=${{ secrets.VERCEL_TOKEN }})" >> $GITHUB_OUTPUT
-      - uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: `✅ Preview deployed: ${{ steps.deploy.outputs.url }}`
-            })
-
-  deploy-preview-env:
-    name: Deploy Preview Env
-    needs: ci
-    if: github.ref == 'refs/heads/preview' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: preview
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm add -g vercel@latest
-      - run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel deploy --prebuilt --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}
-
   semantic-release:
     name: Release
     needs: ci
@@ -105,25 +51,4 @@ jobs:
           GIT_COMMITTER_NAME: github-actions[bot]
           GIT_COMMITTER_EMAIL: github-actions[bot]@users.noreply.github.com
 
-  deploy-production:
-    name: Deploy Production
-    needs: semantic-release
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-    runs-on: ubuntu-latest
-    env:
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-      VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: main
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: 'pnpm'
-      - run: pnpm install --frozen-lockfile
-      - run: pnpm add -g vercel@latest
-      - run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
-      - run: vercel deploy --prebuilt --prod --archive=tgz --token=${{ secrets.VERCEL_TOKEN }}
+  


### PR DESCRIPTION
## Summary

The , , and  jobs all fail because they call `vercel pull/build/deploy` with an unset/invalid `VERCEL_TOKEN` secret:

```
Error: The token provided via `--token` argument is not valid.
```

Vercel deploys are now handled by the **Vercel GitHub integration**, which auto-deploys preview and production environments automatically when CI checks pass — so the manual CLI deploy steps are redundant (and were causing double-deploys).

## Changes

Removed these jobs from `.github/workflows/ci.yml`:
- `deploy-preview` (PR preview deploys + comment)
- `deploy-preview-env` (push-to-preview branch deploys)
- `deploy-production` (push-to-main post-release deploys)

Kept:
- `ci` — lint, type-check, unit + integration tests
- `semantic-release` — version bump + GitHub release on main

## Verification

Workflow YAML is valid. No runtime behavior change to lint/test/release — those jobs are untouched. The removed jobs were already failing, so this can only improve CI status.
