### PR TITLE
ci: enable auto-merge on release-please PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+      - name: Enable auto-merge on release PR
+        if: ${{ steps.release.outputs.prs_created == 'true' }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ fromJson(steps.release.outputs.pr).number }}
+        run: gh pr merge --auto --rebase "$PR_NUMBER"


### PR DESCRIPTION
## Summary

Adds a post-release-please step to the workflow that runs `gh pr merge --auto --rebase` on the created Release PR. This eliminates the manual merge step for release PRs — they will merge automatically once CI passes.

Repo auto-merge has already been enabled via the API (`allow_auto_merge: true`).

## How the new flow works

1. Feature PR merges to `main`
2. `release-please` workflow runs, opens/updates `chore(main): release X.Y.Z` PR
3. New step: `gh pr merge --auto --rebase` is called on that PR — it queues for auto-merge
4. CI runs on the release PR; once green, GitHub auto-merges it
5. release-please tags `vX.Y.Z` and creates the GitHub release on the next push

Fully hands-off after the feature PR merge.

## Notes

- Uses `--rebase` to match the `allowed_merge_methods: ["rebase"]` in the repo's `protected main` ruleset.
- Uses `GITHUB_TOKEN` (no PAT needed) — the token has `pull-requests: write` permission in the workflow.
- The `prs_created` output and `pr` JSON output are official release-please-action v4 outputs ([docs](https://github.com/googleapis/release-please-action#outputs)).

This was originally part of #26 but that PR was merged before this commit landed.