### PR TITLE
fix: resolve code scanning security alerts

### DIFF
--- a/src/app/[locale]/about/page-client.tsx
+++ b/src/app/[locale]/about/page-client.tsx
@@ -202,12 +202,7 @@ export default function AboutPage() {
                       >
                         <div className="flex flex-col items-center space-y-3">
                           <div
-                            className={`p-3 rounded-xl ${color
-                              .replace("text-", "text-")
-                              .replace(
-                                "bg-",
-                                "bg-",
-                              )} transition-all duration-300 group-hover:scale-125 group-hover:rotate-12`}
+                            className={`p-3 rounded-xl ${color} transition-all duration-300 group-hover:scale-125 group-hover:rotate-12`}
                           >
                             <Icon className="h-6 w-6 transition-all duration-300" />
                           </div>

--- a/src/lib/__tests__/recipe-scraper.test.ts
+++ b/src/lib/__tests__/recipe-scraper.test.ts
@@ -322,7 +322,10 @@ describe('RecipeScraper Security Tests', () => {
         }
 
         // Handle specific sites that should have suggestions
-        if (url.includes('bbcgoodfood.com') || url.includes('bbc.co.uk')) {
+        const hostnameMatches = (domain: string) => 
+          urlObj.hostname === domain || urlObj.hostname.endsWith(`.${domain}`);
+        
+        if (hostnameMatches('bbcgoodfood.com') || hostnameMatches('bbc.co.uk')) {
           return {
             success: false,
             source: 'failed' as const,
@@ -334,8 +337,8 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('youtube.com') || url.includes('instagram.com') || 
-            url.includes('facebook.com') || url.includes('pinterest.com')) {
+        if (hostnameMatches('youtube.com') || hostnameMatches('instagram.com') || 
+            hostnameMatches('facebook.com') || hostnameMatches('pinterest.com')) {
           return {
             success: false,
             source: 'failed' as const,
@@ -349,8 +352,8 @@ describe('RecipeScraper Security Tests', () => {
         }
 
         // Check for blocked sites that should provide domain-specific suggestions
-        if (url.includes('food.com') || url.includes('tasty.co') || 
-            url.includes('foodnetwork.com') || url.includes('epicurious.com')) {
+        if (hostnameMatches('food.com') || hostnameMatches('tasty.co') || 
+            hostnameMatches('foodnetwork.com') || hostnameMatches('epicurious.com')) {
           return {
             success: false,
             source: 'failed' as const,
@@ -363,7 +366,7 @@ describe('RecipeScraper Security Tests', () => {
         }
 
         // Handle AH.nl specifically (from MSW handler)
-        if (url.includes('ah.nl')) {
+        if (hostnameMatches('ah.nl')) {
           return {
             success: false,
             source: 'failed' as const,
@@ -375,7 +378,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('marmiton.org')) {
+        if (hostnameMatches('marmiton.org')) {
           return {
             success: false,
             source: 'failed' as const,
@@ -386,7 +389,7 @@ describe('RecipeScraper Security Tests', () => {
           };
         }
 
-        if (url.includes('chefkoch.de')) {
+        if (hostnameMatches('chefkoch.de')) {
           return {
             success: false,
             source: 'failed' as const,
@@ -398,7 +401,7 @@ describe('RecipeScraper Security Tests', () => {
         }
 
         // Handle detailed-error-site specifically
-        if (url.includes('detailed-error-site.com')) {
+        if (hostnameMatches('detailed-error-site.com')) {
           return {
             success: false,
             source: 'failed' as const,

--- a/src/lib/scraper/sanitize.ts
+++ b/src/lib/scraper/sanitize.ts
@@ -4,19 +4,32 @@ const MAX_JSON_LENGTH = 100_000;
 export function sanitizeText(text: string): string {
   // Remove potentially dangerous tags. We avoid the 's' (dotAll) flag for broader TS target compatibility.
   // '[\s\S]*?' is used to simulate dotAll non-greedy matches.
+  // Note: Use <\/script[\s>] to match both </script> and </script > (with space)
   return text
-    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, "")
-    .replace(/<iframe[^>]*>[\s\S]*?<\/iframe>/gi, "")
-    .replace(/<object[^>]*>[\s\S]*?<\/object>/gi, "")
+    .replace(/<script[^>]*>[\s\S]*?<\/script[\s>]/gi, "")
+    .replace(/<iframe[^>]*>[\s\S]*?<\/iframe[\s>]/gi, "")
+    .replace(/<object[^>]*>[\s\S]*?<\/object[\s>]/gi, "")
     .replace(/<embed[^>]*>/gi, "")
+    .replace(/<script[^>]*>/gi, "")
+    .replace(/<iframe[^>]*>/gi, "")
+    .replace(/<object[^>]*>/gi, "")
     .replace(/javascript:/gi, "")
-    .replace(/data:text\/html/gi, "")
+    .replace(/vbscript:/gi, "")
+    .replace(/data:/gi, "")
     .trim();
 }
 
+const DANGEROUS_URL_SCHEMES = /^(javascript|vbscript|data):/i;
+
 export function sanitizeUrl(url: string): string {
   try {
+    if (DANGEROUS_URL_SCHEMES.test(url.trim())) {
+      return "[INVALID_URL]";
+    }
     const urlObj = new URL(url);
+    if (DANGEROUS_URL_SCHEMES.test(urlObj.protocol)) {
+      return "[INVALID_URL]";
+    }
     return `${urlObj.origin}${urlObj.pathname}`;
   } catch {
     return "[INVALID_URL]";


### PR DESCRIPTION
## Summary

Fixes all open GitHub code scanning alerts (17 total) identified by CodeQL.

## Changes

### High Severity Fixes

**`src/lib/scraper/sanitize.ts`** (Alerts #29-32)
- Fixed incomplete HTML tag sanitization that could allow `<script>` and `<iframe>` injection
  - Regex now matches closing tags with trailing whitespace (`</script >`)
  - Added cleanup passes to remove orphaned opening tags
- Added blocking for `vbscript:` and `data:` URL schemes in addition to `javascript:`

**`src/lib/__tests__/recipe-scraper.test.ts`** (Alerts #13-23)
- Replaced unsafe `url.includes()` substring matching with proper hostname validation
- Added `hostnameMatches()` helper that checks exact hostname or subdomain matches
- Prevents false positives where `evil-bbcgoodfood.com` would match `bbcgoodfood.com`

### Medium Severity Fixes

**`src/app/[locale]/about/page-client.tsx`** (Alerts #27-28)
- Removed dead identity string replacements (`.replace("text-", "text-")`)
- These were no-ops that CodeQL flagged as suspicious

## Testing

- All 385 unit tests pass
- Lint clean (0 errors, 2 pre-existing warnings)
- Type checks pass

## Impact

These fixes improve security hardening of the recipe scraper's HTML sanitization and URL validation logic. The test file changes ensure mock URL matching is more precise and won't accidentally match malicious domains.