### PR TITLE
feat: improve assistant and authentication flow

### DIFF
--- a/ToDo.md
+++ b/ToDo.md
@@ -5,6 +5,13 @@
 ## Neon Auth Migration Follow-ups
 
 1. [ ] Implement localized magic link emails via Neon Auth / Better Auth custom email sending hook (currently `locale` is passed through but unused — see `auth-context.tsx` TODO)
+1. [ ] Keep PWA authentication sessions alive for returning users — investigate session expiry and target at least 30 days of inactivity
+1. [ ] Fix post-login routing so users reliably land on the locale-aware `/recipes` page instead of being sent back to the homepage
+
+## AI & Operations
+
+1. [x] Switch the AI assistant to `gpt-5.6-luna` for text and image requests
+1. [ ] Replace the release-please preview → main → approval loop with a simpler release workflow for solo development
 
 ## Quality & Compliance
 

--- a/ToDo.md
+++ b/ToDo.md
@@ -6,7 +6,7 @@
 
 1. [ ] Implement localized magic link emails via Neon Auth / Better Auth custom email sending hook (currently `locale` is passed through but unused — see `auth-context.tsx` TODO)
 1. [ ] Keep PWA authentication sessions alive for returning users — investigate session expiry and target at least 30 days of inactivity
-1. [ ] Fix post-login routing so users reliably land on the locale-aware `/recipes` page instead of being sent back to the homepage
+1. [x] Fix post-login routing so users reliably land on the locale-aware `/recipes` page instead of being sent back to the homepage
 
 ## AI & Operations
 

--- a/docs/architecture-review.md
+++ b/docs/architecture-review.md
@@ -16,7 +16,7 @@ Meal Maestro is a Next.js 16 + React 19 application using the App Router, deploy
 | Language | TypeScript 5.9.3 (strict mode) |
 | Database | Neon (Postgres) via Drizzle ORM 0.45.1 |
 | Auth | Neon Auth / Better Auth 0.2.0-beta.1 |
-| AI | OpenAI API 6.0.0 (gpt-4.1-mini + gpt-4o) |
+| AI | OpenAI API 6.0.0 (gpt-5.6-luna) |
 | Storage | Cloudflare R2 via AWS SDK S3 |
 | Email | Resend |
 | Styling | Tailwind CSS v4 + shadcn/ui |

--- a/src/app/[locale]/login/page-client.test.tsx
+++ b/src/app/[locale]/login/page-client.test.tsx
@@ -1,0 +1,114 @@
+import type { ReactNode } from "react";
+import { render, waitFor } from "@testing-library/react";
+import LoginPage from "./page-client";
+
+const authState = vi.hoisted(() => ({
+  user: null as { id: string } | null,
+  loading: true,
+}));
+
+const router = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+const searchParams = vi.hoisted(() => new URLSearchParams());
+
+const childMocks = vi.hoisted(() => ({
+  googleLogin: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/app/i18n/routing", () => ({
+  routing: {
+    locales: ["nl", "en"],
+    defaultLocale: "nl",
+  },
+  useRouter: () => router,
+}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParams,
+}));
+
+vi.mock("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: () => (key: string) => key,
+}));
+
+vi.mock("@/components/auth/google-login-button", () => ({
+  GoogleLoginButton: (props: Record<string, unknown>) => {
+    childMocks.googleLogin(props);
+    return <button type="button">google</button>;
+  },
+}));
+
+vi.mock("@/components/auth/email-password-form", () => ({
+  EmailPasswordForm: () => <div data-testid="email-password-form" />,
+}));
+
+vi.mock("@/components/ui/page-loading", () => ({
+  PageLoading: () => <div data-testid="page-loading" />,
+}));
+
+vi.mock("@/components/ui/page-wrapper", () => ({
+  PageWrapper: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/chef-hat-icon", () => ({
+  ChefHatIcon: () => <div data-testid="chef-hat" />,
+}));
+
+describe("LoginPage post-login routing", () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.loading = true;
+    searchParams.delete("redirectTo");
+    searchParams.delete("error");
+    vi.clearAllMocks();
+  });
+
+  it("waits for the session before redirecting and uses the active locale", async () => {
+    const view = render(<LoginPage />);
+
+    expect(router.replace).not.toHaveBeenCalled();
+
+    authState.loading = false;
+    view.rerender(<LoginPage />);
+    expect(router.replace).not.toHaveBeenCalled();
+
+    authState.user = { id: "user-1" };
+    view.rerender(<LoginPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/recipes", { locale: "en" });
+    });
+    expect(router.replace).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the full locale-aware destination to Google", () => {
+    authState.loading = false;
+
+    render(<LoginPage />);
+
+    expect(childMocks.googleLogin).toHaveBeenCalledWith(
+      expect.objectContaining({ redirectPath: "/en/recipes", locale: "en" }),
+    );
+  });
+
+  it("honors a localized redirect target", async () => {
+    searchParams.set("redirectTo", "/nl/recipes");
+    authState.loading = false;
+
+    const view = render(<LoginPage />);
+    authState.user = { id: "user-1" };
+    view.rerender(<LoginPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/recipes", { locale: "nl" });
+    });
+  });
+});

--- a/src/app/[locale]/login/page-client.tsx
+++ b/src/app/[locale]/login/page-client.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState, Suspense } from "react";
+import { useEffect, useMemo, useRef, useState, Suspense } from "react";
 import { useRouter } from "@/app/i18n/routing";
 import { useSearchParams } from "next/navigation";
 import { useAuth } from "@/lib/auth-context";
@@ -12,7 +12,10 @@ import { PageLoading } from "@/components/ui/page-loading";
 import { PageWrapper } from "@/components/ui/page-wrapper";
 import { ChefHatIcon } from "@/components/ui/chef-hat-icon";
 import { useLocale, useTranslations } from 'next-intl';
-import { sanitizeRedirectPath, resolveLocaleAwarePath } from "@/lib/auth-redirect";
+import {
+  sanitizeRedirectPath,
+  resolveLocaleAwareNavigationTarget,
+} from "@/lib/auth-redirect";
 import { routing } from "@/app/i18n/routing";
 
 function LoginContent() {
@@ -29,24 +32,28 @@ function LoginContent() {
     return sanitizeRedirectPath(raw);
   }, [searchParams]);
 
-  const callbackRedirectPath = useMemo(() => {
+  const postLoginTarget = useMemo(() => {
     const basePath = redirectParam ?? '/recipes';
-    const { path } = resolveLocaleAwarePath({
+    return resolveLocaleAwareNavigationTarget({
       path: basePath,
       locale,
       availableLocales: routing.locales,
       defaultLocale: routing.defaultLocale,
     });
-    return path;
   }, [redirectParam, locale]);
 
+  const hasRedirected = useRef(false);
+
   useEffect(() => {
-    // Redirect authenticated users to recipes
-    if (!loading && user) {
-      router.push(redirectParam ?? '/recipes');
+    // Wait for the confirmed session before leaving the login page.
+    if (!loading && user && !hasRedirected.current) {
+      hasRedirected.current = true;
+      router.replace(postLoginTarget.pathname, {
+        locale: postLoginTarget.locale,
+      });
       return;
     }
-  }, [user, loading, router, redirectParam]);
+  }, [user, loading, router, postLoginTarget]);
 
   useEffect(() => {
     // Handle authentication errors from callback
@@ -135,7 +142,7 @@ function LoginContent() {
 
                 <div className="space-y-4">
                   <GoogleLoginButton
-                    redirectPath={callbackRedirectPath}
+                    redirectPath={postLoginTarget.path}
                     locale={locale}
                   />
 
@@ -150,7 +157,7 @@ function LoginContent() {
                     </div>
                   </div>
 
-                  <EmailPasswordForm redirectPath={redirectParam ?? "/recipes"} />
+                  <EmailPasswordForm />
                 </div>
 
                 <div className="text-xs text-muted-foreground leading-relaxed">

--- a/src/app/[locale]/recipes/page.test.tsx
+++ b/src/app/[locale]/recipes/page.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import RecipesPage from "./page";
+
+const authState = vi.hoisted(() => ({
+  user: null as { id: string } | null,
+  loading: true,
+}));
+
+const router = vi.hoisted(() => ({
+  push: vi.fn(),
+  replace: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => authState,
+}));
+
+vi.mock("@/app/i18n/routing", () => ({
+  useRouter: () => router,
+}));
+
+vi.mock("@/lib/hooks/use-recipes-query", () => ({
+  useRecipesQuery: () => ({
+    data: { recipes: [] },
+    isLoading: false,
+    isError: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock("@/components/recipes/recipe-columns", () => ({
+  useRecipeColumns: () => ({ columns: [] }),
+}));
+
+vi.mock("@/components/recipes/recipe-data-table", () => ({
+  RecipeDataTable: () => <div data-testid="recipe-data-table" />,
+}));
+
+vi.mock("@/components/ui/page-loading", () => ({
+  PageLoading: () => <div data-testid="page-loading" />,
+}));
+
+vi.mock("@/components/ui/page-wrapper", () => ({
+  PageWrapper: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock("@/components/ui/page-header", () => ({
+  PageHeader: () => <div data-testid="page-header" />,
+}));
+
+vi.mock("next-intl", () => ({
+  useTranslations: () => (key: string) => key,
+}));
+
+describe("RecipesPage auth routing", () => {
+  beforeEach(() => {
+    authState.user = null;
+    authState.loading = true;
+    vi.clearAllMocks();
+  });
+
+  it("does not redirect while authentication is loading", () => {
+    render(<RecipesPage />);
+
+    expect(screen.getByTestId("page-loading")).toBeInTheDocument();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+
+  it("returns unauthenticated users to localized login with the recipes target", async () => {
+    const view = render(<RecipesPage />);
+
+    authState.loading = false;
+    view.rerender(<RecipesPage />);
+
+    await waitFor(() => {
+      expect(router.replace).toHaveBeenCalledWith("/login?redirectTo=/recipes");
+    });
+    expect(router.replace).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders recipes for an authenticated user without redirecting", () => {
+    authState.loading = false;
+    authState.user = { id: "user-1" };
+
+    render(<RecipesPage />);
+
+    expect(screen.getByTestId("page-header")).toBeInTheDocument();
+    expect(router.replace).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/[locale]/recipes/page.tsx
+++ b/src/app/[locale]/recipes/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useRef } from "react";
 import { useRouter } from "@/app/i18n/routing";
 import { useAuth } from "@/lib/auth-context";
 import { useRecipesQuery } from "@/lib/hooks/use-recipes-query";
@@ -16,12 +16,14 @@ import { useTranslations } from "next-intl";
 export default function RecipesPage() {
   const router = useRouter();
   const { user, loading } = useAuth();
+  const hasRedirected = useRef(false);
   const t = useTranslations("recipes");
   const { columns } = useRecipeColumns();
 
   useEffect(() => {
-    if (!loading && !user) {
-      router.push("/");
+    if (!loading && !user && !hasRedirected.current) {
+      hasRedirected.current = true;
+      router.replace("/login?redirectTo=/recipes");
     }
   }, [loading, user, router]);
 

--- a/src/app/auth/callback/page.tsx
+++ b/src/app/auth/callback/page.tsx
@@ -5,6 +5,11 @@ import { useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { PageLoading } from "@/components/ui/page-loading";
 import { authClient } from "@/lib/auth/client";
+import { routing } from "@/app/i18n/routing";
+import {
+  resolveLocaleAwareNavigationTarget,
+  resolveLocaleAwarePath,
+} from "@/lib/auth-redirect";
 
 /**
  * OAuth callback page.
@@ -17,23 +22,57 @@ export default function AuthCallback() {
   const router = useRouter();
 
   useEffect(() => {
+    let cancelled = false;
+
+    const getRedirectTarget = () => {
+      const searchParams = new URLSearchParams(window.location.search);
+      return resolveLocaleAwareNavigationTarget({
+        path: searchParams.get("redirectTo"),
+        locale: searchParams.get("locale"),
+        availableLocales: routing.locales,
+        defaultLocale: routing.defaultLocale,
+      });
+    };
+
+    const redirectToLoginWithError = (error: string) => {
+      const target = getRedirectTarget();
+      const loginPath = resolveLocaleAwarePath({
+        path: "/login",
+        locale: target.locale,
+        availableLocales: routing.locales,
+        defaultLocale: routing.defaultLocale,
+      }).path;
+      const params = new URLSearchParams({
+        error,
+        redirectTo: target.pathname,
+      });
+
+      router.replace(`${loginPath}?${params.toString()}`);
+    };
+
     const checkSession = async () => {
       // Give Neon Auth a moment to set the session cookie
       await new Promise((resolve) => setTimeout(resolve, 500));
 
+      if (cancelled) return;
+
       try {
         const { data: session } = await authClient.getSession();
         if (session?.user) {
-          router.replace("/nl/recipes");
+          router.replace(getRedirectTarget().path);
         } else {
-          router.replace("/nl?error=auth_error");
+          redirectToLoginWithError("auth_error");
         }
       } catch {
-        router.replace("/nl?error=auth_error");
+        redirectToLoginWithError("auth_error");
       }
     };
 
     checkSession();
+
+    return () => {
+      cancelled = true;
+    };
   }, [router]);
 
   return (

--- a/src/components/auth/__tests__/email-password-form.test.tsx
+++ b/src/components/auth/__tests__/email-password-form.test.tsx
@@ -1,0 +1,69 @@
+import type { ReactNode } from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { EmailPasswordForm } from "../email-password-form";
+
+const authMocks = vi.hoisted(() => ({
+  signInWithEmail: vi.fn(),
+  signUpWithEmail: vi.fn(),
+}));
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+}));
+
+vi.mock("@/lib/auth-context", () => ({
+  useAuth: () => authMocks,
+}));
+
+vi.mock("sonner", () => ({
+  toast: toastMocks,
+}));
+
+vi.mock("next/link", () => ({
+  default: ({ children, ...props }: { children: ReactNode; href: string }) => (
+    <a {...props}>{children}</a>
+  ),
+}));
+
+describe("EmailPasswordForm", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("authenticates without performing navigation", async () => {
+    const user = userEvent.setup();
+    authMocks.signInWithEmail.mockResolvedValue({});
+
+    render(<EmailPasswordForm />);
+
+    await user.type(screen.getByPlaceholderText("emailPlaceholder"), "user@example.com");
+    await user.type(screen.getByPlaceholderText("passwordPlaceholder"), "password123");
+    await user.click(screen.getByRole("button", { name: "signIn" }));
+
+    await waitFor(() => {
+      expect(authMocks.signInWithEmail).toHaveBeenCalledWith(
+        "user@example.com",
+        "password123",
+      );
+    });
+    expect(screen.getByRole("button", { name: "signIn" })).toBeInTheDocument();
+    expect(toastMocks.error).not.toHaveBeenCalled();
+  });
+
+  it("does not navigate after a failed sign-in", async () => {
+    const user = userEvent.setup();
+    authMocks.signInWithEmail.mockResolvedValue({ error: "invalid credentials" });
+
+    render(<EmailPasswordForm />);
+
+    await user.type(screen.getByPlaceholderText("emailPlaceholder"), "user@example.com");
+    await user.type(screen.getByPlaceholderText("passwordPlaceholder"), "password123");
+    await user.click(screen.getByRole("button", { name: "signIn" }));
+
+    await waitFor(() => {
+      expect(toastMocks.error).toHaveBeenCalledWith("signInError");
+    });
+    expect(authMocks.signInWithEmail).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/auth/email-password-form.tsx
+++ b/src/components/auth/email-password-form.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useState } from "react";
-import { useRouter } from "@/app/i18n/routing";
 import { useAuth } from "@/lib/auth-context";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -10,13 +9,8 @@ import { useTranslations } from "next-intl";
 import { toast } from "sonner";
 import Link from "next/link";
 
-interface EmailPasswordFormProps {
-  redirectPath?: string | null;
-}
-
-export function EmailPasswordForm({ redirectPath }: EmailPasswordFormProps) {
+export function EmailPasswordForm() {
   const { signInWithEmail, signUpWithEmail } = useAuth();
-  const router = useRouter();
   const t = useTranslations("auth");
 
   const [mode, setMode] = useState<"signIn" | "signUp">("signIn");
@@ -67,7 +61,6 @@ export function EmailPasswordForm({ redirectPath }: EmailPasswordFormProps) {
         }
       }
 
-      router.push(redirectPath ?? "/recipes");
     } finally {
       setIsLoading(false);
     }

--- a/src/lib/__tests__/auth-context.test.tsx
+++ b/src/lib/__tests__/auth-context.test.tsx
@@ -1,0 +1,83 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, waitFor } from "@testing-library/react";
+import { AuthProvider, useAuth } from "../auth-context";
+
+const authClientMocks = vi.hoisted(() => ({
+  refetchSession: vi.fn().mockResolvedValue(undefined),
+  signInEmail: vi.fn().mockResolvedValue({ error: null }),
+  signUpEmail: vi.fn().mockResolvedValue({ error: null }),
+  signInSocial: vi.fn(),
+  signOut: vi.fn(),
+  requestPasswordReset: vi.fn(),
+  changePassword: vi.fn(),
+}));
+
+vi.mock("@/lib/auth/client", () => ({
+  authClient: {
+    useSession: () => ({
+      data: null,
+      isPending: false,
+      isRefetching: false,
+      refetch: authClientMocks.refetchSession,
+    }),
+    signIn: {
+      email: authClientMocks.signInEmail,
+      social: authClientMocks.signInSocial,
+    },
+    signUp: {
+      email: authClientMocks.signUpEmail,
+    },
+    signOut: authClientMocks.signOut,
+    requestPasswordReset: authClientMocks.requestPasswordReset,
+    changePassword: authClientMocks.changePassword,
+  },
+}));
+
+function SignInProbe() {
+  const { signInWithEmail } = useAuth();
+
+  return (
+    <button
+      type="button"
+      onClick={() => void signInWithEmail("user@example.com", "password123")}
+    >
+      sign in
+    </button>
+  );
+}
+
+function renderProbe() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <SignInProbe />
+      </AuthProvider>
+    </QueryClientProvider>,
+  );
+}
+
+describe("AuthProvider session handoff", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("refreshes the session after a successful email sign-in", async () => {
+    const view = renderProbe();
+
+    fireEvent.click(view.getByRole("button", { name: "sign in" }));
+
+    await waitFor(() => {
+      expect(authClientMocks.signInEmail).toHaveBeenCalledWith({
+        email: "user@example.com",
+        password: "password123",
+      });
+      expect(authClientMocks.refetchSession).toHaveBeenCalledWith({
+        query: { disableCookieCache: true },
+      });
+    });
+  });
+});

--- a/src/lib/__tests__/auth-redirect.test.ts
+++ b/src/lib/__tests__/auth-redirect.test.ts
@@ -1,6 +1,7 @@
 import {
   consumePendingAuthRedirect,
   getPendingAuthRedirect,
+  resolveLocaleAwareNavigationTarget,
   resolveLocaleAwarePath,
   sanitizeRedirectPath,
   setPendingAuthRedirect,
@@ -81,6 +82,49 @@ describe("auth-redirect utilities", () => {
       defaultLocale,
     });
     expect(resolvedQuery).toEqual({ path: "/en?foo=bar", locale: "en" });
+  });
+
+  it("creates next-intl navigation targets without duplicating locale prefixes", () => {
+    const locales = ["nl", "en"] as const;
+
+    expect(
+      resolveLocaleAwareNavigationTarget({
+        path: "/recipes",
+        locale: "en",
+        availableLocales: locales,
+        defaultLocale: "nl",
+      }),
+    ).toEqual({
+      path: "/en/recipes",
+      pathname: "/recipes",
+      locale: "en",
+    });
+
+    expect(
+      resolveLocaleAwareNavigationTarget({
+        path: "/en/recipes?filter=favorites",
+        locale: "nl",
+        availableLocales: locales,
+        defaultLocale: "nl",
+      }),
+    ).toEqual({
+      path: "/en/recipes?filter=favorites",
+      pathname: "/recipes?filter=favorites",
+      locale: "en",
+    });
+
+    expect(
+      resolveLocaleAwareNavigationTarget({
+        path: "/",
+        locale: "en",
+        availableLocales: locales,
+        defaultLocale: "nl",
+      }),
+    ).toEqual({
+      path: "/en",
+      pathname: "/",
+      locale: "en",
+    });
   });
 
   it("clears pending redirects", () => {

--- a/src/lib/auth-context.tsx
+++ b/src/lib/auth-context.tsx
@@ -38,7 +38,12 @@ interface AuthProviderProps {
 
 export function AuthProvider({ children }: AuthProviderProps) {
   const queryClient = useQueryClient();
-  const { data: sessionData, isPending } = authClient.useSession();
+  const {
+    data: sessionData,
+    isPending,
+    isRefetching,
+    refetch: refetchSession,
+  } = authClient.useSession();
 
   const user = useMemo(
     () =>
@@ -51,10 +56,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
           }
         : null,
     [
-      sessionData?.user?.id,
-      sessionData?.user?.email,
-      sessionData?.user?.name,
-      sessionData?.user?.image,
+      sessionData?.user,
     ],
   );
 
@@ -66,7 +68,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             expiresAt: sessionData.session.expiresAt,
           }
         : null,
-    [sessionData?.session?.id, sessionData?.session?.expiresAt],
+    [sessionData?.session],
   );
 
   const profileQueryKey = ["user-profile", user?.id];
@@ -116,9 +118,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (error) {
         return { error: error.message ?? "Failed to sign in" };
       }
+      await refetchSession({ query: { disableCookieCache: true } });
       return {};
     },
-    [],
+    [refetchSession],
   );
 
   const signUpWithEmail = useCallback(
@@ -127,9 +130,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       if (error) {
         return { error: error.message ?? "Failed to create account" };
       }
+      await refetchSession({ query: { disableCookieCache: true } });
       return {};
     },
-    [],
+    [refetchSession],
   );
 
   const requestPasswordReset = useCallback(
@@ -175,7 +179,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     user,
     session,
     profile,
-    loading: isPending || profileLoading,
+    loading: isPending || isRefetching || profileLoading,
     signInWithGoogle,
     signInWithEmail,
     signUpWithEmail,

--- a/src/lib/auth-redirect.ts
+++ b/src/lib/auth-redirect.ts
@@ -93,6 +93,12 @@ type LocaleAwarePathOptions = {
   defaultLocale: string;
 };
 
+export type LocaleAwareNavigationTarget = {
+  path: string;
+  pathname: string;
+  locale: string;
+};
+
 export const resolveLocaleAwarePath = ({
   path,
   locale,
@@ -125,4 +131,26 @@ export const resolveLocaleAwarePath = ({
   }
 
   return { path: `/${normalizedLocale}${sanitizedPath}`, locale: normalizedLocale };
+};
+
+export const resolveLocaleAwareNavigationTarget = (
+  options: LocaleAwarePathOptions,
+): LocaleAwareNavigationTarget => {
+  const resolved = resolveLocaleAwarePath(options);
+  const localePrefix = `/${resolved.locale}`;
+
+  let pathname = resolved.path;
+  if (pathname === localePrefix) {
+    pathname = "/";
+  } else if (
+    pathname.startsWith(`${localePrefix}/`) ||
+    pathname.startsWith(`${localePrefix}?`)
+  ) {
+    pathname = pathname.slice(localePrefix.length);
+  }
+
+  return {
+    ...resolved,
+    pathname,
+  };
 };

--- a/src/lib/openai-service.ts
+++ b/src/lib/openai-service.ts
@@ -30,9 +30,9 @@ export class OpenAITimeoutError extends ApplicationError {
 
 // OpenAI Configuration
 const OPENAI_API_KEY = process.env.OPENAI_API_KEY || "";
-const OPENAI_TEXT_MODEL = "gpt-4.1-mini"; // For text-only conversations
-const OPENAI_VISION_MODEL = "gpt-4o"; // For conversations with images
-const OPENAI_MAX_TOKENS = parseInt("2000", 10);
+const OPENAI_TEXT_MODEL = "gpt-5.6-luna"; // For text-only conversations
+const OPENAI_VISION_MODEL = "gpt-5.6-luna"; // GPT-5.6 Luna also supports image input
+const OPENAI_MAX_COMPLETION_TOKENS = parseInt("2000", 10);
 const OPENAI_TEMPERATURE = parseFloat("0.9");
 
 if (!OPENAI_API_KEY) {
@@ -83,7 +83,7 @@ export async function createChatCompletion(
       messages,
       tools,
       tool_choice: toolChoice || (tools ? "auto" : undefined),
-      max_tokens: OPENAI_MAX_TOKENS,
+      max_completion_tokens: OPENAI_MAX_COMPLETION_TOKENS,
       temperature: OPENAI_TEMPERATURE,
     });
 

--- a/src/lib/pricing-config.ts
+++ b/src/lib/pricing-config.ts
@@ -12,6 +12,9 @@ export interface ModelPricingConfig {
 
 export const OPENAI_PRICING: Record<string, ModelPricingConfig> = {
   // GPT-5 Series
+  'gpt-5.6-luna': {
+    standard: { input: 0.20, cached_input: 0.02, output: 1.20 }
+  },
   'gpt-5': {
     standard: { input: 1.25, cached_input: 0.125, output: 10.00 },
     batch: { input: 0.625, cached_input: 0.0625, output: 5.00 },


### PR DESCRIPTION
## Summary
- Switch the AI assistant to GPT-5.6 Luna for text and image requests.
- Make post-login routing locale-aware and session-ready.
- Prevent transient auth state from sending users back to the homepage.
- Add focused auth, routing, and protected-page tests.
- Mark the completed post-login routing roadmap item.

## Verification
- `pnpm test`
- `pnpm test:integration`
- `pnpm exec tsc --noEmit`
- `pnpm lint`
- `pnpm build`

## Notes
- Magic-link/email webhook work remains disabled and out of scope.
- Neon Auth trusted-domain configuration was corrected separately for production.