### PR TITLE
fix: repair release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
       - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
           RELEASE_TAG: ${{ steps.package.outputs.tag }}
           RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |

--- a/src/lib/openai-service.ts
+++ b/src/lib/openai-service.ts
@@ -83,6 +83,8 @@ export async function createChatCompletion(
       messages,
       tools,
       tool_choice: toolChoice || (tools ? "auto" : undefined),
+      // Chat Completions only permits this model's function tools without reasoning.
+      reasoning_effort: tools?.length ? "none" : undefined,
       max_completion_tokens: OPENAI_MAX_COMPLETION_TOKENS,
       temperature: OPENAI_TEMPERATURE,
     });


### PR DESCRIPTION
## Summary
- set `GH_REPO` for GitHub CLI release commands so they do not depend on a checked-out Git repository
- include the pending Luna function-tool compatibility fix
- include the existing CI code-scanning retry adjustment

## Verification
- `release.yml` parses as YAML
- `git diff --check`